### PR TITLE
Add agree block scanning for Python model comparison

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -15,8 +15,12 @@ var checkCmd = &cobra.Command{
 	Use:   "check",
 	Short: "Check your tracked schemas for missing changes.",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		fmt.Println("check called")
-		parser.ParseBytes()
+		sqlModels, pydModels, err := parser.ParsePythonFiles("test-data")
+		if err != nil {
+			return err
+		}
+		report := parser.CompareModels(sqlModels, pydModels)
+		fmt.Println(report)
 		return nil
 	},
 }

--- a/pkg/parser/python_models.go
+++ b/pkg/parser/python_models.go
@@ -1,0 +1,235 @@
+package parser
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	ts "github.com/tree-sitter/go-tree-sitter"
+	py "github.com/tree-sitter/tree-sitter-python/bindings/go"
+)
+
+// Field represents a single field with a name and type.
+type Field struct {
+	Name string
+	Type string
+}
+
+// Model represents a parsed model with its fields.
+type Model struct {
+	Name   string
+	Fields map[string]Field
+}
+
+// agreeBlock represents a single agree section inside a file.
+type agreeBlock struct {
+	Nickname string
+	Type     string
+	Code     string
+}
+
+// ParsePythonFiles walks the given directory, reads all files and parses agree
+// blocks tagged as either "sqlalchemy" or "pydantic".
+func ParsePythonFiles(dir string) (map[string]Model, map[string]Model, error) {
+	sqlModels := make(map[string]Model)
+	pydModels := make(map[string]Model)
+
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		src, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		blocks := extractAgreeBlocks(string(src))
+		for _, b := range blocks {
+			switch b.Type {
+			case "sqlalchemy":
+				m, err := parsePythonModel([]byte(b.Code), "sqlalchemy")
+				if err != nil {
+					return fmt.Errorf("%s: %w", path, err)
+				}
+				sqlModels[b.Nickname] = m
+			case "pydantic":
+				m, err := parsePythonModel([]byte(b.Code), "pydantic")
+				if err != nil {
+					return fmt.Errorf("%s: %w", path, err)
+				}
+				pydModels[b.Nickname] = m
+			}
+		}
+		return nil
+	})
+	return sqlModels, pydModels, err
+}
+
+// extractAgreeBlocks scans the given text for agree comment blocks.
+func extractAgreeBlocks(src string) []agreeBlock {
+	lines := strings.Split(src, "\n")
+	var blocks []agreeBlock
+	var current *agreeBlock
+	for _, line := range lines {
+		if current == nil {
+			if idx := strings.Index(line, "[agree:"); idx != -1 {
+				rest := line[idx+len("[agree:"):]
+				end := strings.Index(rest, "]")
+				if end == -1 {
+					continue
+				}
+				header := rest[:end]
+				parts := strings.SplitN(header, ":", 2)
+				if len(parts) != 2 {
+					continue
+				}
+				current = &agreeBlock{Nickname: strings.TrimSpace(parts[0]), Type: strings.TrimSpace(parts[1])}
+				current.Code = ""
+			}
+			continue
+		}
+		if strings.Contains(line, "[agree:end]") {
+			blocks = append(blocks, *current)
+			current = nil
+			continue
+		}
+		current.Code += line + "\n"
+	}
+	return blocks
+}
+
+// parsePythonModel parses one Python class definition from src. modelType must
+// be either "sqlalchemy" or "pydantic".
+func parsePythonModel(src []byte, modelType string) (Model, error) {
+	parser := ts.NewParser()
+	parser.SetLanguage(ts.NewLanguage(py.Language()))
+	tree := parser.Parse(src, nil)
+	defer tree.Close()
+
+	root := tree.RootNode()
+	for i := uint(0); i < root.NamedChildCount(); i++ {
+		n := root.NamedChild(i)
+		if n.Kind() != "class_definition" {
+			continue
+		}
+		nameNode := n.ChildByFieldName("name")
+		if nameNode == nil {
+			continue
+		}
+		className := nameNode.Utf8Text(src)
+		body := n.ChildByFieldName("body")
+		fields := make(map[string]Field)
+		if body != nil {
+			for j := uint(0); j < body.NamedChildCount(); j++ {
+				stmt := body.NamedChild(j)
+				if stmt.Kind() != "expression_statement" {
+					continue
+				}
+				assign := stmt.NamedChild(0)
+				if assign == nil || assign.Kind() != "assignment" {
+					continue
+				}
+				left := assign.ChildByFieldName("left")
+				if left == nil || left.Kind() != "identifier" {
+					continue
+				}
+				fieldName := left.Utf8Text(src)
+				if strings.HasPrefix(fieldName, "__") {
+					continue
+				}
+				var fieldType string
+				if t := assign.ChildByFieldName("type"); t != nil {
+					fieldType = t.Utf8Text(src)
+				}
+				if modelType == "sqlalchemy" {
+					r := assign.ChildByFieldName("right")
+					if r == nil || r.Kind() != "call" {
+						continue
+					}
+					fn := r.ChildByFieldName("function")
+					if fn == nil || fn.Utf8Text(src) != "Column" {
+						continue
+					}
+					args := r.ChildByFieldName("arguments")
+					if args != nil && args.NamedChildCount() > 0 {
+						first := args.NamedChild(0)
+						fieldType = first.Utf8Text(src)
+					}
+				}
+				fields[fieldName] = Field{Name: fieldName, Type: normalizeType(fieldType)}
+			}
+		}
+		return Model{Name: className, Fields: fields}, nil
+	}
+	return Model{}, fmt.Errorf("no class definition found")
+}
+
+// normalizeType normalizes simple python/sqlalchemy type names.
+func normalizeType(t string) string {
+	t = strings.TrimSpace(strings.ToLower(t))
+	if idx := strings.Index(t, "|"); idx > 0 {
+		t = strings.TrimSpace(t[:idx])
+	}
+	switch t {
+	case "integer", "int":
+		return "int"
+	case "string", "str":
+		return "str"
+	case "float":
+		return "float"
+	case "boolean", "bool":
+		return "bool"
+	case "emailstr":
+		return "emailstr"
+	}
+	return t
+}
+
+// CompareModels compares SQLAlchemy models with Pydantic models and returns a report.
+func CompareModels(sqlModels, pydModels map[string]Model) string {
+	var sb strings.Builder
+	for nick, sqlModel := range sqlModels {
+		pydModel, ok := pydModels[nick]
+		if !ok {
+			continue
+		}
+		missingSQL := []string{}
+		missingPyd := []string{}
+		typeMismatch := []string{}
+		for fname, f := range pydModel.Fields {
+			sf, ok := sqlModel.Fields[fname]
+			if !ok {
+				missingSQL = append(missingSQL, fname)
+				continue
+			}
+			if sf.Type != f.Type {
+				typeMismatch = append(typeMismatch, fmt.Sprintf("%s (%s != %s)", fname, sf.Type, f.Type))
+			}
+		}
+		for fname := range sqlModel.Fields {
+			if _, ok := pydModel.Fields[fname]; !ok {
+				missingPyd = append(missingPyd, fname)
+			}
+		}
+		if len(missingSQL)+len(missingPyd)+len(typeMismatch) > 0 {
+			sb.WriteString(fmt.Sprintf("Model %s:\n", nick))
+			if len(missingSQL) > 0 {
+				sb.WriteString("  Missing in SQLAlchemy: " + strings.Join(missingSQL, ", ") + "\n")
+			}
+			if len(missingPyd) > 0 {
+				sb.WriteString("  Missing in Pydantic: " + strings.Join(missingPyd, ", ") + "\n")
+			}
+			if len(typeMismatch) > 0 {
+				sb.WriteString("  Type mismatches: " + strings.Join(typeMismatch, ", ") + "\n")
+			}
+		}
+	}
+	if sb.Len() == 0 {
+		return "No mismatches found"
+	}
+	return sb.String()
+}

--- a/pkg/parser/python_models_test.go
+++ b/pkg/parser/python_models_test.go
@@ -1,0 +1,35 @@
+package parser
+
+import "testing"
+
+func TestParsePythonFiles(t *testing.T) {
+	sql, pyd, err := ParsePythonFiles("../../test-data")
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	if len(sql) != 1 {
+		t.Fatalf("expected 1 sql model, got %d", len(sql))
+	}
+	if len(pyd) != 1 {
+		t.Fatalf("expected 1 pydantic model, got %d", len(pyd))
+	}
+	m := sql["user"]
+	if _, ok := m.Fields["id"]; !ok {
+		t.Fatalf("sql model missing field id")
+	}
+	pm := pyd["user"]
+	if _, ok := pm.Fields["username"]; !ok {
+		t.Fatalf("pyd model missing field username")
+	}
+}
+
+func TestCompareModels(t *testing.T) {
+	sql, pyd, err := ParsePythonFiles("../../test-data")
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	rep := CompareModels(sql, pyd)
+	if rep == "" {
+		t.Fatalf("expected report")
+	}
+}

--- a/test-data/pydantic.py
+++ b/test-data/pydantic.py
@@ -1,3 +1,4 @@
+# [agree:user:pydantic]
 class UserSchema(BaseModel):
     id: int
     username: str
@@ -6,3 +7,4 @@ class UserSchema(BaseModel):
 
     class Config:
         orm_mode = True
+# [agree:end]

--- a/test-data/sql_alchemy.py
+++ b/test-data/sql_alchemy.py
@@ -1,6 +1,8 @@
+# [agree:user:sqlalchemy]
 class User(Base):
     __tablename__ = "users"
     id = Column(Integer, primary_key=True)
     username = Column(String, unique=True, nullable=False)
     email = Column(String, unique=True, nullable=False)
     full_name = Column(String)
+# [agree:end]


### PR DESCRIPTION
## Summary
- parse `[agree:nickname:type]` blocks when scanning files
- extract sqlalchemy and pydantic models from those blocks
- compare models by nickname
- update tests and example data to use agree blocks

## Testing
- `go test ./...`
- `go run . check`

------
https://chatgpt.com/codex/tasks/task_e_68637f17c2188320bceac1102d4aa9e8